### PR TITLE
Fix empty invites display

### DIFF
--- a/web/src/components/InvitesTable.tsx
+++ b/web/src/components/InvitesTable.tsx
@@ -429,6 +429,14 @@ export const InvitesTable: React.FC = () => {
     );
   }
 
+  if (invites.length === 0) {
+    return (
+      <div className="text-center py-8">
+        <p className="text-gray-600 text-lg">No invite requests</p>
+      </div>
+    );
+  }
+
   return (
     <div>
       <div className="mb-4">

--- a/web/src/components/__tests__/InvitesTable.test.tsx
+++ b/web/src/components/__tests__/InvitesTable.test.tsx
@@ -316,4 +316,43 @@ describe('InvitesTable', () => {
       expect(screen.getByText('Error - Try Again')).toBeInTheDocument();
     });
   });
+
+  it('displays message when there are no invites', async () => {
+    // Mock empty invites response
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve([]),
+    });
+
+    render(<InvitesTable />);
+    
+    // Wait for loading to complete
+    await waitFor(() => {
+      expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
+    });
+
+    // Check that the "No invite requests" message is displayed
+    expect(screen.getByText('No invite requests')).toBeInTheDocument();
+    
+    // Verify that no table is rendered
+    expect(screen.queryByRole('table')).not.toBeInTheDocument();
+  });
+
+  it('handles API error when fetching invites', async () => {
+    // Mock failed API response
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+    });
+
+    render(<InvitesTable />);
+    
+    // Wait for error state
+    await waitFor(() => {
+      expect(screen.getByText('Error: Failed to fetch invites')).toBeInTheDocument();
+    });
+    
+    // Verify that no table is rendered
+    expect(screen.queryByRole('table')).not.toBeInTheDocument();
+  });
 }); 


### PR DESCRIPTION
## Summary
- Fixed bug where an empty table was shown when there are no invite requests
- Now displays a user-friendly "No invite requests" message instead

## Test plan
- [ ] Load the application when there are no invites in the system
- [ ] Verify that "No invite requests" message is displayed instead of an empty table
- [ ] Add new invites and verify the table displays correctly

🤖 Generated with [Claude Code](https://claude.ai/code)