### PR TITLE
Fix clipboard copy functionality

### DIFF
--- a/web/src/components/InvitesTable.tsx
+++ b/web/src/components/InvitesTable.tsx
@@ -62,12 +62,40 @@ export const InvitesTable: React.FC = () => {
 
   const handleCopyEmails = async () => {
     const emailList = approvedInvites.map(invite => invite.email).join(', ');
+    
     try {
-      await navigator.clipboard.writeText(emailList);
-      setCopySuccess(true);
-      setTimeout(() => setCopySuccess(false), 2000);
+      // Try using the modern clipboard API first
+      if (navigator.clipboard && window.isSecureContext) {
+        await navigator.clipboard.writeText(emailList);
+        setCopySuccess(true);
+        setTimeout(() => setCopySuccess(false), 2000);
+      } else {
+        // Fallback for older browsers or non-secure contexts
+        const textArea = document.createElement('textarea');
+        textArea.value = emailList;
+        textArea.style.position = 'fixed';
+        textArea.style.left = '-999999px';
+        textArea.style.top = '-999999px';
+        document.body.appendChild(textArea);
+        textArea.focus();
+        textArea.select();
+        
+        try {
+          const successful = document.execCommand('copy');
+          if (successful) {
+            setCopySuccess(true);
+            setTimeout(() => setCopySuccess(false), 2000);
+          } else {
+            console.error('Failed to copy emails using fallback method');
+          }
+        } finally {
+          document.body.removeChild(textArea);
+        }
+      }
     } catch (err) {
       console.error('Failed to copy emails:', err);
+      // Optionally show user-friendly error message
+      alert('Failed to copy emails to clipboard. Please copy manually.');
     }
   };
 


### PR DESCRIPTION
## Summary
- Fixed clipboard copy button not working in all browser contexts
- Added fallback method using `document.execCommand` for non-secure contexts or older browsers
- Improved error handling with user-friendly alert message

## Technical Details
The clipboard API (`navigator.clipboard.writeText`) requires a secure context (HTTPS) to work. This fix:
1. First attempts to use the modern clipboard API if available and in secure context
2. Falls back to the legacy `document.execCommand('copy')` method for HTTP or older browsers
3. Shows an alert to the user if both methods fail

## Test Plan
- [ ] Test clipboard copy in HTTPS context (modern browsers)
- [ ] Test clipboard copy in HTTP context (should use fallback)
- [ ] Test clipboard copy in older browsers without modern API
- [ ] Verify success message appears when copy succeeds
- [ ] Verify error alert appears when copy fails
- [ ] Run automated tests: `npm test`

🤖 Generated with [Claude Code](https://claude.ai/code)