### PR TITLE
Remove nginx API proxy for k8s portability

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -52,7 +52,7 @@ This is a Go-based Slack invite management application with a React TypeScript f
 
 ### Infrastructure
 - **Containerization**: Docker with multi-service docker-compose
-- **Web Server**: Nginx (reverse proxy in production)
+- **Web Server**: Nginx (static file serving in production)
 - **SSL**: Let's Encrypt
 - **CI/CD**: GitHub Actions with automated testing and deployment
 - **Email**: SMTP2Go for notifications
@@ -176,8 +176,8 @@ docker compose -f docker-compose.sheets.yml up -d
 - `backend/Dockerfile.sheets` - Sheets service container definition
 - `web/Dockerfile` - Frontend production container
 - `web/Dockerfile.dev` - Frontend development container
-- `web/nginx.conf.template` - Nginx configuration template (uses `envsubst` for `PUBLIC_URL` and `API_URL`)
-- `web/public/config.js` - Runtime configuration template (generated at container startup with `PUBLIC_URL`)
+- `web/nginx.conf.template` - Nginx configuration template (static file serving only)
+- `web/public/config.js` - Runtime configuration template (generated at container startup with `PUBLIC_URL` and `API_URL`)
 - `backend/go.mod` - Go dependencies
 - `web/package.json` - Node.js dependencies
 
@@ -224,6 +224,8 @@ docker compose -f docker-compose.sheets.yml up -d
 - **Backend API** always on port 8080
 - **Database** is SQLite for both dev and production (in `data/` directory)
 - **Subpath deployment** is fully configurable at runtime via `PUBLIC_URL` environment variable - no rebuild required
+- **API URL** is configured via `API_URL` environment variable - must be browser-accessible (not internal docker hostname)
+- **Frontend makes direct API calls** - nginx does not proxy API requests, making the container portable for k8s deployments
 
 ## Getting Help
 

--- a/docker-compose.app.yml
+++ b/docker-compose.app.yml
@@ -14,12 +14,13 @@ services:
     restart: unless-stopped
 
   # Production web service
+  # Note: API_URL must be browser-accessible (not internal docker hostname)
   web:
     image: ghcr.io/${GITHUB_USERNAME}/slack-invite-mgr-web:latest
     ports:
       - "80:80"
     environment:
-      - API_URL=http://app:8080
+      - API_URL=http://localhost:8080
       - PUBLIC_URL=/slack-invite
     depends_on:
       - app

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -34,7 +34,6 @@ ENV PUBLIC_URL=
 EXPOSE 80
 
 # At container startup:
-# 1. Generate config.js with runtime PUBLIC_URL for API calls
-# 2. Apply envsubst to nginx config for proxy routes
-# 3. Start nginx
-CMD ["/bin/sh", "-c", "echo \"window.APP_CONFIG = { PUBLIC_URL: '${PUBLIC_URL}' };\" > /usr/share/nginx/html/config.js && envsubst '$$API_URL $$PUBLIC_URL' < /etc/nginx/templates/default.conf.template > /etc/nginx/conf.d/default.conf && nginx -g 'daemon off;'"] 
+# 1. Generate config.js with runtime PUBLIC_URL and API_URL for frontend
+# 2. Start nginx (no envsubst needed - nginx config has no variables)
+CMD ["/bin/sh", "-c", "echo \"window.APP_CONFIG = { PUBLIC_URL: '${PUBLIC_URL}', API_URL: '${API_URL}' };\" > /usr/share/nginx/html/config.js && cp /etc/nginx/templates/default.conf.template /etc/nginx/conf.d/default.conf && nginx -g 'daemon off;'"] 

--- a/web/nginx.conf.template
+++ b/web/nginx.conf.template
@@ -8,26 +8,4 @@ server {
         index index.html;
         try_files $uri $uri/ /index.html;
     }
-
-    # Proxy API requests to the backend
-    # This handles both root path (/api/) and subpath deployments (${PUBLIC_URL}/api/)
-    location /api/ {
-        proxy_pass ${API_URL};
-        proxy_http_version 1.1;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection 'upgrade';
-        proxy_set_header Host $host;
-        proxy_cache_bypass $http_upgrade;
-    }
-
-    # Proxy API requests when deployed at a subpath
-    # Only active if PUBLIC_URL is set (e.g., /slack-invite)
-    location ${PUBLIC_URL}/api/ {
-        proxy_pass ${API_URL};
-        proxy_http_version 1.1;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection 'upgrade';
-        proxy_set_header Host $host;
-        proxy_cache_bypass $http_upgrade;
-    }
 } 

--- a/web/public/config.js
+++ b/web/public/config.js
@@ -1,5 +1,6 @@
 // Runtime configuration - this file is generated at container startup
-// For development, PUBLIC_URL defaults to empty string (root path)
+// For development, these default to empty strings
 window.APP_CONFIG = {
-  PUBLIC_URL: ''
+  PUBLIC_URL: '',
+  API_URL: ''
 };

--- a/web/src/components/InvitesTable.tsx
+++ b/web/src/components/InvitesTable.tsx
@@ -22,11 +22,11 @@ export const InvitesTable: React.FC = () => {
   const [copySuccess, setCopySuccess] = useState(false);
   const [updateStatus, setUpdateStatus] = useState<'idle' | 'loading' | 'success' | 'error'>('idle');
 
-  // Get the base URL for API calls, respecting PUBLIC_URL for subpath deployments
-  // Uses runtime config (window.APP_CONFIG) which is generated at container startup
+  // Get the full URL for API calls using runtime API_URL configuration
+  // API_URL is set at container startup via window.APP_CONFIG
   const getApiUrl = (endpoint: string) => {
-    const publicUrl = (window as any).APP_CONFIG?.PUBLIC_URL || '';
-    return `${publicUrl}/api${endpoint}`;
+    const apiUrl = (window as any).APP_CONFIG?.API_URL || '';
+    return `${apiUrl}${endpoint}`;
   };
 
   const fetchInvites = async () => {


### PR DESCRIPTION
## Summary
- Remove API proxy blocks from nginx.conf.template - nginx now only serves static files
- Add `API_URL` to runtime config.js for direct frontend API calls from browser
- Update Dockerfile and docker-compose.app.yml to support the new configuration
- Update documentation to reflect the breaking change

## Motivation
The web container previously used nginx to proxy API requests to the backend. This is not portable for Kubernetes deployments where Ingress controllers or service meshes handle routing. By removing the proxy, the container becomes a simple static file server that works with any external routing solution.

## Breaking Change
`API_URL` must now be a **browser-accessible** URL, not an internal docker/container hostname.

| Deployment | Before | After |
|------------|--------|-------|
| docker-compose | `http://app:8080` | `http://localhost:8080` |
| Kubernetes | N/A | Ingress URL (e.g., `https://api.example.com`) |

## Test plan
- [ ] Verify frontend loads and can make API calls in docker-compose environment
- [ ] Verify `API_URL` is correctly injected into config.js at container startup
- [ ] Test with k8s deployment using Ingress for API routing

🤖 Generated with [Claude Code](https://claude.com/claude-code)