### PR TITLE
Add email template to sheets Docker image with SMTP config

### DIFF
--- a/backend/Dockerfile.sheets
+++ b/backend/Dockerfile.sheets
@@ -23,11 +23,15 @@ WORKDIR /app
 # Copy the binary from builder
 COPY --from=builder /app/sheets .
 
+# Copy templates directory
+COPY --from=builder /app/templates /app/templates
+
 # Create directory for credentials
 RUN mkdir -p /app/credentials
 
 # Set environment variables
 ENV GOOGLE_CREDENTIALS_FILE=/app/credentials/credentials.json
+ENV EMAIL_TEMPLATE_PATH=/app/templates/email_template.html
 
 # Run the application
 CMD ["./sheets"] 

--- a/backend/templates/email_template.html
+++ b/backend/templates/email_template.html
@@ -14,7 +14,7 @@
             padding: 0;
             background-color: #f4f4f4;
         }
-        
+
         /* Container */
         .container {
             max-width: 600px;
@@ -23,7 +23,7 @@
             border-radius: 8px;
             box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
         }
-        
+
         /* Header */
         .header {
             background-color: #4A154B; /* Slack purple */
@@ -32,25 +32,25 @@
             border-radius: 8px 8px 0 0;
             text-align: center;
         }
-        
+
         .header h1 {
             margin: 0;
             font-size: 24px;
             font-weight: 600;
         }
-        
+
         /* Content */
         .content {
             padding: 30px;
             background-color: #ffffff;
         }
-        
+
         .message {
             font-size: 16px;
             color: #333333;
             margin-bottom: 20px;
         }
-        
+
         /* Footer */
         .footer {
             padding: 20px;
@@ -61,14 +61,14 @@
             background-color: #fafafa;
             border-radius: 0 0 8px 8px;
         }
-        
+
         /* Responsive design */
         @media only screen and (max-width: 600px) {
             .container {
                 margin: 10px;
                 width: auto;
             }
-            
+
             .content {
                 padding: 20px;
             }
@@ -85,8 +85,8 @@
                 %s
             </div>
             <div class="processing-links">
-                <a href="https://example.com/a">A</a>
-                <a href="https://example.com/b">B</a>
+                <p><a href="http://homehub.local:8181">HomeHub Local Network</a></p>
+                <p><a href="http://homehub.tail27ddc5.ts.net:8181">HomeHub Tailscale</a></p>
             </div>
         </div>
         <div class="footer">
@@ -95,4 +95,4 @@
         </div>
     </div>
 </body>
-</html> 
+</html>

--- a/docker-compose.sheets.yml
+++ b/docker-compose.sheets.yml
@@ -8,6 +8,9 @@ services:
       - GOOGLE_SPREADSHEET_ID=${GOOGLE_SPREADSHEET_ID}
       - GOOGLE_SHEET_NAME=${GOOGLE_SHEET_NAME}
       - EMAIL_RECIPIENT=${EMAIL_RECIPIENT}
+      - SMTP2GO_FROM_EMAIL=${SMTP2GO_FROM_EMAIL}
+      - SMTP2GO_USERNAME=${SMTP2GO_USERNAME}
+      - SMTP2GO_PASSWORD=${SMTP2GO_PASSWORD}
     volumes:
       - ./data/credentials.json:/app/credentials/credentials.json
     restart: unless-stopped 


### PR DESCRIPTION
## Summary
- Bundle `email_template.html` into the sheets Docker image by default
- Set default `EMAIL_TEMPLATE_PATH` environment variable in Dockerfile
- Update email template with actual HomeHub links (local network + Tailscale)
- Add missing SMTP2GO credentials to `docker-compose.sheets.yml`

## Test plan
- [ ] Build the sheets Docker image and verify template is included at `/app/templates/email_template.html`
- [ ] Deploy with SMTP2GO credentials and verify emails are sent with the styled template
- [ ] Verify HomeHub links in email notifications work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)