### PR TITLE
Add configurable DASHBOARD_URL for email template

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Required environment variables:
 - `SMTP2GO_FROM_EMAIL`: Your verified sender email address (for sheets service)
 - `SMTP2GO_USERNAME`: Your SMTP2Go username (for sheets service)
 - `SMTP2GO_PASSWORD`: Your SMTP2Go API key (for sheets service)
+- `DASHBOARD_URL`: URL for the dashboard link in email notifications (for sheets service)
 - `GITHUB_USERNAME`: Your GitHub username (for container registry)
 
 Optional environment variables:
@@ -60,6 +61,7 @@ export EMAIL_RECIPIENT="notifications@example.com"
 export SMTP2GO_FROM_EMAIL="your.email@yourdomain.com"
 export SMTP2GO_USERNAME="your-smtp2go-username"
 export SMTP2GO_PASSWORD="your-smtp2go-api-key"
+export DASHBOARD_URL="https://your-dashboard-url.example.com"
 export GITHUB_USERNAME="your-github-username"
 ```
 

--- a/backend/internal/services/email.go
+++ b/backend/internal/services/email.go
@@ -53,6 +53,12 @@ func NewEmailService(recipient string, templatePath string) *EmailService {
 			panic(fmt.Sprintf("failed to read email template: %v", err))
 		}
 		template = string(templateBytes)
+
+		// Replace dashboard URL placeholder if environment variable is set
+		dashboardURL := os.Getenv("DASHBOARD_URL")
+		if dashboardURL != "" {
+			template = strings.Replace(template, "{{DASHBOARD_URL}}", dashboardURL, -1)
+		}
 	}
 
 	return &EmailService{

--- a/backend/templates/email_template.html
+++ b/backend/templates/email_template.html
@@ -85,8 +85,7 @@
                 %s
             </div>
             <div class="processing-links">
-                <p><a href="http://homehub.local:8181">HomeHub Local Network</a></p>
-                <p><a href="http://homehub.tail27ddc5.ts.net:8181">HomeHub Tailscale</a></p>
+                <p><a href="{{DASHBOARD_URL}}">Open Dashboard</a></p>
             </div>
         </div>
         <div class="footer">

--- a/docker-compose.sheets.yml
+++ b/docker-compose.sheets.yml
@@ -11,6 +11,7 @@ services:
       - SMTP2GO_FROM_EMAIL=${SMTP2GO_FROM_EMAIL}
       - SMTP2GO_USERNAME=${SMTP2GO_USERNAME}
       - SMTP2GO_PASSWORD=${SMTP2GO_PASSWORD}
+      - DASHBOARD_URL=${DASHBOARD_URL}
     volumes:
       - ./data/credentials.json:/app/credentials/credentials.json
     restart: unless-stopped 


### PR DESCRIPTION
## Summary
- Replace hardcoded links in email template with a single configurable link
- Add `DASHBOARD_URL` environment variable support for k8s/docker deployments
- Remove exposed Tailscale address from default template

## Changes
- **email_template.html**: Single link with `{{DASHBOARD_URL}}` placeholder
- **email.go**: Substitutes placeholder with env var at template load time
- **docker-compose.sheets.yml**: Added `DASHBOARD_URL` env var
- **README.md**: Documented new environment variable

## Test plan
- [ ] Set `DASHBOARD_URL` env var and verify email contains correct link
- [ ] Verify email service starts without `DASHBOARD_URL` set (placeholder remains)
- [ ] Run `go build ./...` to confirm compilation

🤖 Generated with [Claude Code](https://claude.com/claude-code)