### PR TITLE
Add Helm charts for Kubernetes deployment via ArgoCD

### DIFF
--- a/helm/argocd/application.yaml
+++ b/helm/argocd/application.yaml
@@ -1,0 +1,47 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: slack-invite-mgr
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/YOUR_USERNAME/slack-invite-mgr.git
+    targetRevision: HEAD
+    path: helm/slack-invite-mgr
+    helm:
+      valueFiles:
+        - values.yaml
+        - values-prod.yaml
+      # Override values inline if needed
+      # parameters:
+      #   - name: global.githubUsername
+      #     value: your-github-username
+      #   - name: ingress.host
+      #     value: slack-invite.your-domain.com
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: slack-invite-mgr
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+      allowEmpty: false
+    syncOptions:
+      - CreateNamespace=true
+      - PrunePropagationPolicy=foreground
+      - PruneLast=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m
+  # Health checks
+  ignoreDifferences:
+    - group: apps
+      kind: Deployment
+      jsonPointers:
+        - /spec/replicas

--- a/helm/slack-invite-mgr/Chart.yaml
+++ b/helm/slack-invite-mgr/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v2
+name: slack-invite-mgr
+description: A Helm chart for deploying Slack Invite Manager to Kubernetes
+type: application
+version: 0.1.0
+appVersion: "1.0.0"
+keywords:
+  - slack
+  - invite
+  - management
+maintainers:
+  - name: Steve Bennett

--- a/helm/slack-invite-mgr/README.md
+++ b/helm/slack-invite-mgr/README.md
@@ -1,0 +1,229 @@
+# Slack Invite Manager Helm Chart
+
+A Helm chart for deploying Slack Invite Manager to Kubernetes via ArgoCD.
+
+## Prerequisites
+
+- Kubernetes 1.19+
+- Helm 3.0+
+- Traefik Ingress Controller
+- External Secrets Operator (ESO) installed
+- A configured SecretStore or ClusterSecretStore
+- ArgoCD (for GitOps deployment)
+
+## Components
+
+This chart deploys the following components:
+
+| Component | Type | Description |
+|-----------|------|-------------|
+| Backend API | Deployment + Service | Go REST API server |
+| Frontend Web | Deployment + Service | React SPA served by nginx |
+| Sheets Sync | CronJob | Scheduled Google Sheets synchronization |
+| Ingress | Traefik IngressRoute | TLS-enabled ingress with path routing |
+| External Secrets | ExternalSecret | Secrets fetched from external store |
+
+## Installation
+
+### Using Helm directly
+
+```bash
+# Add your values
+helm install slack-invite-mgr ./helm/slack-invite-mgr \
+  --namespace slack-invite-mgr \
+  --create-namespace \
+  -f values-prod.yaml \
+  --set global.githubUsername=your-username \
+  --set externalSecrets.secretStoreName=your-secret-store
+```
+
+### Using ArgoCD
+
+1. Update `helm/argocd/application.yaml` with your repository URL
+2. Apply the ArgoCD Application:
+
+```bash
+kubectl apply -f helm/argocd/application.yaml
+```
+
+## Configuration
+
+### Required Values
+
+| Parameter | Description |
+|-----------|-------------|
+| `global.githubUsername` | GitHub username for container registry |
+| `externalSecrets.secretStoreName` | Name of your SecretStore/ClusterSecretStore |
+| `ingress.host` | Hostname for the ingress |
+| `web.env.apiUrl` | Browser-accessible API URL |
+
+### External Secrets Setup
+
+Before deploying, ensure your external secret store contains:
+
+1. **Google Credentials** (`google-credentials`):
+   - `credentials.json`: Google service account JSON
+
+2. **App Secrets** (`slack-invite/app`):
+   - `spreadsheetId`: Google Spreadsheet ID
+   - `sheetName`: Sheet name within the spreadsheet
+
+3. **SMTP Secrets** (`slack-invite/smtp`) - only needed if sheets is enabled:
+   - `emailRecipient`: Notification email address
+   - `fromEmail`: Sender email address
+   - `username`: SMTP2Go username
+   - `password`: SMTP2Go API key
+   - `dashboardUrl`: Dashboard URL for email templates
+
+### Full Configuration Reference
+
+See `values.yaml` for all available configuration options.
+
+#### Global Settings
+
+```yaml
+global:
+  imageRegistry: ghcr.io
+  githubUsername: "your-username"
+  imagePullSecrets: []
+```
+
+#### Backend Configuration
+
+```yaml
+backend:
+  enabled: true
+  replicas: 1
+  port: 8080
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 256Mi
+```
+
+#### Frontend Configuration
+
+```yaml
+web:
+  enabled: true
+  replicas: 1
+  port: 80
+  env:
+    apiUrl: "https://slack-invite.example.com/api"
+    publicUrl: "/slack-invite"
+```
+
+#### Sheets CronJob Configuration
+
+```yaml
+sheets:
+  enabled: true
+  schedule: "0 * * * *"  # Every hour
+  concurrencyPolicy: Forbid
+```
+
+#### Ingress Configuration
+
+```yaml
+ingress:
+  enabled: true
+  host: slack-invite.example.com
+  path: /slack-invite
+  entryPoints:
+    - websecure
+  tls:
+    enabled: true
+    secretName: slack-invite-tls
+```
+
+#### External Secrets Configuration
+
+```yaml
+externalSecrets:
+  enabled: true
+  secretStoreName: "your-secret-store"
+  secretStoreKind: ClusterSecretStore
+  refreshInterval: 1h
+  googleCredentials:
+    remoteRef: google-credentials
+  appSecrets:
+    remoteRef: slack-invite/app
+  smtpSecrets:
+    remoteRef: slack-invite/smtp
+```
+
+## Upgrading
+
+```bash
+helm upgrade slack-invite-mgr ./helm/slack-invite-mgr \
+  --namespace slack-invite-mgr \
+  -f values-prod.yaml
+```
+
+Or with ArgoCD, simply push changes to your Git repository.
+
+## Uninstalling
+
+```bash
+helm uninstall slack-invite-mgr --namespace slack-invite-mgr
+```
+
+Or delete the ArgoCD Application:
+
+```bash
+kubectl delete application slack-invite-mgr -n argocd
+```
+
+## Troubleshooting
+
+### Pods not starting
+
+Check if secrets are being created:
+
+```bash
+kubectl get externalsecrets -n slack-invite-mgr
+kubectl get secrets -n slack-invite-mgr
+```
+
+### API connection issues
+
+Ensure `web.env.apiUrl` is set to a browser-accessible URL, not an internal service URL.
+
+### CronJob not running
+
+Check the CronJob status:
+
+```bash
+kubectl get cronjobs -n slack-invite-mgr
+kubectl get jobs -n slack-invite-mgr
+```
+
+## Architecture
+
+```
+                    ┌─────────────────┐
+                    │    Traefik      │
+                    │   IngressRoute  │
+                    └────────┬────────┘
+                             │
+              ┌──────────────┼──────────────┐
+              │              │              │
+              ▼              ▼              │
+    ┌─────────────┐  ┌─────────────┐       │
+    │   Web (80)  │  │ Backend     │       │
+    │   nginx     │  │ API (8080)  │       │
+    └─────────────┘  └──────┬──────┘       │
+                            │              │
+                            ▼              │
+                    ┌─────────────┐        │
+                    │   Sheets    │◄───────┘
+                    │   CronJob   │  (scheduled)
+                    └─────────────┘
+```
+
+## License
+
+See LICENSE file in the root of the repository.

--- a/helm/slack-invite-mgr/templates/_helpers.tpl
+++ b/helm/slack-invite-mgr/templates/_helpers.tpl
@@ -1,0 +1,161 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "slack-invite-mgr.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "slack-invite-mgr.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "slack-invite-mgr.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "slack-invite-mgr.labels" -}}
+helm.sh/chart: {{ include "slack-invite-mgr.chart" . }}
+{{ include "slack-invite-mgr.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "slack-invite-mgr.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "slack-invite-mgr.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Backend labels
+*/}}
+{{- define "slack-invite-mgr.backend.labels" -}}
+{{ include "slack-invite-mgr.labels" . }}
+app.kubernetes.io/component: backend
+{{- end }}
+
+{{/*
+Backend selector labels
+*/}}
+{{- define "slack-invite-mgr.backend.selectorLabels" -}}
+{{ include "slack-invite-mgr.selectorLabels" . }}
+app.kubernetes.io/component: backend
+{{- end }}
+
+{{/*
+Web labels
+*/}}
+{{- define "slack-invite-mgr.web.labels" -}}
+{{ include "slack-invite-mgr.labels" . }}
+app.kubernetes.io/component: web
+{{- end }}
+
+{{/*
+Web selector labels
+*/}}
+{{- define "slack-invite-mgr.web.selectorLabels" -}}
+{{ include "slack-invite-mgr.selectorLabels" . }}
+app.kubernetes.io/component: web
+{{- end }}
+
+{{/*
+Sheets labels
+*/}}
+{{- define "slack-invite-mgr.sheets.labels" -}}
+{{ include "slack-invite-mgr.labels" . }}
+app.kubernetes.io/component: sheets
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "slack-invite-mgr.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "slack-invite-mgr.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create image name with registry
+*/}}
+{{- define "slack-invite-mgr.image" -}}
+{{- $registry := .global.imageRegistry -}}
+{{- $username := .global.githubUsername -}}
+{{- $repository := .image.repository -}}
+{{- $tag := .image.tag -}}
+{{- if $username }}
+{{- printf "%s/%s/%s:%s" $registry $username $repository $tag }}
+{{- else }}
+{{- printf "%s/%s:%s" $registry $repository $tag }}
+{{- end }}
+{{- end }}
+
+{{/*
+Backend image
+*/}}
+{{- define "slack-invite-mgr.backend.image" -}}
+{{- include "slack-invite-mgr.image" (dict "global" .Values.global "image" .Values.backend.image) }}
+{{- end }}
+
+{{/*
+Web image
+*/}}
+{{- define "slack-invite-mgr.web.image" -}}
+{{- include "slack-invite-mgr.image" (dict "global" .Values.global "image" .Values.web.image) }}
+{{- end }}
+
+{{/*
+Sheets image
+*/}}
+{{- define "slack-invite-mgr.sheets.image" -}}
+{{- include "slack-invite-mgr.image" (dict "global" .Values.global "image" .Values.sheets.image) }}
+{{- end }}
+
+{{/*
+Image pull secrets
+*/}}
+{{- define "slack-invite-mgr.imagePullSecrets" -}}
+{{- with .Values.global.imagePullSecrets }}
+imagePullSecrets:
+{{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}
+
+{{/*
+Secret names
+*/}}
+{{- define "slack-invite-mgr.googleCredentialsSecretName" -}}
+{{- printf "%s-google-credentials" (include "slack-invite-mgr.fullname" .) }}
+{{- end }}
+
+{{- define "slack-invite-mgr.appSecretsName" -}}
+{{- printf "%s-app-secrets" (include "slack-invite-mgr.fullname" .) }}
+{{- end }}
+
+{{- define "slack-invite-mgr.smtpSecretsName" -}}
+{{- printf "%s-smtp-secrets" (include "slack-invite-mgr.fullname" .) }}
+{{- end }}

--- a/helm/slack-invite-mgr/templates/backend-deployment.yaml
+++ b/helm/slack-invite-mgr/templates/backend-deployment.yaml
@@ -1,0 +1,96 @@
+{{- if .Values.backend.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "slack-invite-mgr.fullname" . }}-backend
+  labels:
+    {{- include "slack-invite-mgr.backend.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.backend.replicas }}
+  selector:
+    matchLabels:
+      {{- include "slack-invite-mgr.backend.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.backend.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "slack-invite-mgr.backend.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- include "slack-invite-mgr.imagePullSecrets" . | nindent 6 }}
+      serviceAccountName: {{ include "slack-invite-mgr.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: backend
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: {{ include "slack-invite-mgr.backend.image" . }}
+          imagePullPolicy: {{ .Values.backend.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.backend.port }}
+              protocol: TCP
+          env:
+            - name: PORT
+              value: {{ .Values.backend.port | quote }}
+            - name: GOOGLE_CREDENTIALS_FILE
+              value: /app/credentials/credentials.json
+            {{- if .Values.externalSecrets.enabled }}
+            - name: GOOGLE_SPREADSHEET_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "slack-invite-mgr.appSecretsName" . }}
+                  key: GOOGLE_SPREADSHEET_ID
+            - name: GOOGLE_SHEET_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "slack-invite-mgr.appSecretsName" . }}
+                  key: GOOGLE_SHEET_NAME
+            {{- else }}
+            - name: GOOGLE_SHEET_NAME
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "slack-invite-mgr.fullname" . }}-config
+                  key: GOOGLE_SHEET_NAME
+            {{- end }}
+            {{- with .Values.backend.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          volumeMounts:
+            - name: google-credentials
+              mountPath: /app/credentials
+              readOnly: true
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.backend.healthCheck.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.backend.healthCheck.initialDelaySeconds }}
+            periodSeconds: {{ .Values.backend.healthCheck.periodSeconds }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.backend.healthCheck.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.backend.healthCheck.initialDelaySeconds }}
+            periodSeconds: {{ .Values.backend.healthCheck.periodSeconds }}
+          resources:
+            {{- toYaml .Values.backend.resources | nindent 12 }}
+      volumes:
+        - name: google-credentials
+          secret:
+            secretName: {{ include "slack-invite-mgr.googleCredentialsSecretName" . }}
+      {{- with .Values.backend.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.backend.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.backend.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/helm/slack-invite-mgr/templates/backend-service.yaml
+++ b/helm/slack-invite-mgr/templates/backend-service.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.backend.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "slack-invite-mgr.fullname" . }}-backend
+  labels:
+    {{- include "slack-invite-mgr.backend.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.backend.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "slack-invite-mgr.backend.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/helm/slack-invite-mgr/templates/configmap.yaml
+++ b/helm/slack-invite-mgr/templates/configmap.yaml
@@ -1,0 +1,10 @@
+{{- if not .Values.externalSecrets.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "slack-invite-mgr.fullname" . }}-config
+  labels:
+    {{- include "slack-invite-mgr.labels" . | nindent 4 }}
+data:
+  GOOGLE_SHEET_NAME: {{ .Values.config.googleSheetName | quote }}
+{{- end }}

--- a/helm/slack-invite-mgr/templates/external-secret.yaml
+++ b/helm/slack-invite-mgr/templates/external-secret.yaml
@@ -1,0 +1,72 @@
+{{- if .Values.externalSecrets.enabled }}
+# Google Credentials Secret
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: {{ include "slack-invite-mgr.googleCredentialsSecretName" . }}
+  labels:
+    {{- include "slack-invite-mgr.labels" . | nindent 4 }}
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
+  secretStoreRef:
+    name: {{ .Values.externalSecrets.secretStoreName }}
+    kind: {{ .Values.externalSecrets.secretStoreKind }}
+  target:
+    name: {{ include "slack-invite-mgr.googleCredentialsSecretName" . }}
+    creationPolicy: Owner
+  data:
+    - secretKey: credentials.json
+      remoteRef:
+        key: {{ .Values.externalSecrets.googleCredentials.remoteRef }}
+        {{- if .Values.externalSecrets.googleCredentials.property }}
+        property: {{ .Values.externalSecrets.googleCredentials.property }}
+        {{- end }}
+---
+# Application Secrets (Spreadsheet ID, Sheet Name)
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: {{ include "slack-invite-mgr.appSecretsName" . }}
+  labels:
+    {{- include "slack-invite-mgr.labels" . | nindent 4 }}
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
+  secretStoreRef:
+    name: {{ .Values.externalSecrets.secretStoreName }}
+    kind: {{ .Values.externalSecrets.secretStoreKind }}
+  target:
+    name: {{ include "slack-invite-mgr.appSecretsName" . }}
+    creationPolicy: Owner
+  data:
+    {{- range $key, $envVar := .Values.externalSecrets.appSecrets.keys }}
+    - secretKey: {{ $envVar }}
+      remoteRef:
+        key: {{ $.Values.externalSecrets.appSecrets.remoteRef }}
+        property: {{ $key }}
+    {{- end }}
+---
+{{- if .Values.sheets.enabled }}
+# SMTP Secrets (Email configuration)
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: {{ include "slack-invite-mgr.smtpSecretsName" . }}
+  labels:
+    {{- include "slack-invite-mgr.labels" . | nindent 4 }}
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
+  secretStoreRef:
+    name: {{ .Values.externalSecrets.secretStoreName }}
+    kind: {{ .Values.externalSecrets.secretStoreKind }}
+  target:
+    name: {{ include "slack-invite-mgr.smtpSecretsName" . }}
+    creationPolicy: Owner
+  data:
+    {{- range $key, $envVar := .Values.externalSecrets.smtpSecrets.keys }}
+    - secretKey: {{ $envVar }}
+      remoteRef:
+        key: {{ $.Values.externalSecrets.smtpSecrets.remoteRef }}
+        property: {{ $key }}
+    {{- end }}
+{{- end }}
+{{- end }}

--- a/helm/slack-invite-mgr/templates/ingress.yaml
+++ b/helm/slack-invite-mgr/templates/ingress.yaml
@@ -1,0 +1,54 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: {{ include "slack-invite-mgr.fullname" . }}
+  labels:
+    {{- include "slack-invite-mgr.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  entryPoints:
+    {{- toYaml .Values.ingress.entryPoints | nindent 4 }}
+  routes:
+    # Route for frontend web application
+    - match: Host(`{{ .Values.ingress.host }}`) && PathPrefix(`{{ .Values.ingress.path }}`)
+      kind: Rule
+      {{- if .Values.ingress.middlewares }}
+      middlewares:
+        {{- toYaml .Values.ingress.middlewares | nindent 8 }}
+      {{- end }}
+      services:
+        - name: {{ include "slack-invite-mgr.fullname" . }}-web
+          port: {{ .Values.web.port }}
+    # Route for backend API (if API is accessed through ingress)
+    - match: Host(`{{ .Values.ingress.host }}`) && PathPrefix(`{{ .Values.ingress.path }}/api`)
+      kind: Rule
+      {{- if .Values.ingress.middlewares }}
+      middlewares:
+        {{- toYaml .Values.ingress.middlewares | nindent 8 }}
+      {{- end }}
+      services:
+        - name: {{ include "slack-invite-mgr.fullname" . }}-backend
+          port: {{ .Values.backend.port }}
+  {{- if .Values.ingress.tls.enabled }}
+  tls:
+    secretName: {{ .Values.ingress.tls.secretName }}
+  {{- end }}
+---
+{{- if .Values.ingress.path }}
+# Middleware to strip the path prefix for the web frontend
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: {{ include "slack-invite-mgr.fullname" . }}-stripprefix
+  labels:
+    {{- include "slack-invite-mgr.labels" . | nindent 4 }}
+spec:
+  stripPrefix:
+    prefixes:
+      - {{ .Values.ingress.path }}
+{{- end }}
+{{- end }}

--- a/helm/slack-invite-mgr/templates/serviceaccount.yaml
+++ b/helm/slack-invite-mgr/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "slack-invite-mgr.serviceAccountName" . }}
+  labels:
+    {{- include "slack-invite-mgr.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/helm/slack-invite-mgr/templates/sheets-cronjob.yaml
+++ b/helm/slack-invite-mgr/templates/sheets-cronjob.yaml
@@ -1,0 +1,106 @@
+{{- if .Values.sheets.enabled }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "slack-invite-mgr.fullname" . }}-sheets
+  labels:
+    {{- include "slack-invite-mgr.sheets.labels" . | nindent 4 }}
+spec:
+  schedule: {{ .Values.sheets.schedule | quote }}
+  concurrencyPolicy: {{ .Values.sheets.concurrencyPolicy }}
+  successfulJobsHistoryLimit: {{ .Values.sheets.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ .Values.sheets.failedJobsHistoryLimit }}
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          {{- with .Values.sheets.podAnnotations }}
+          annotations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          labels:
+            {{- include "slack-invite-mgr.sheets.labels" . | nindent 12 }}
+        spec:
+          {{- include "slack-invite-mgr.imagePullSecrets" . | nindent 10 }}
+          serviceAccountName: {{ include "slack-invite-mgr.serviceAccountName" . }}
+          securityContext:
+            {{- toYaml .Values.podSecurityContext | nindent 12 }}
+          restartPolicy: {{ .Values.sheets.restartPolicy }}
+          containers:
+            - name: sheets
+              securityContext:
+                {{- toYaml .Values.securityContext | nindent 16 }}
+              image: {{ include "slack-invite-mgr.sheets.image" . }}
+              imagePullPolicy: {{ .Values.sheets.image.pullPolicy }}
+              env:
+                - name: GOOGLE_CREDENTIALS_FILE
+                  value: /app/credentials/credentials.json
+                - name: EMAIL_TEMPLATE_PATH
+                  value: /app/templates/email_template.html
+                {{- if .Values.externalSecrets.enabled }}
+                # App secrets
+                - name: GOOGLE_SPREADSHEET_ID
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ include "slack-invite-mgr.appSecretsName" . }}
+                      key: GOOGLE_SPREADSHEET_ID
+                - name: GOOGLE_SHEET_NAME
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ include "slack-invite-mgr.appSecretsName" . }}
+                      key: GOOGLE_SHEET_NAME
+                # SMTP secrets
+                - name: EMAIL_RECIPIENT
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ include "slack-invite-mgr.smtpSecretsName" . }}
+                      key: EMAIL_RECIPIENT
+                - name: SMTP2GO_FROM_EMAIL
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ include "slack-invite-mgr.smtpSecretsName" . }}
+                      key: SMTP2GO_FROM_EMAIL
+                - name: SMTP2GO_USERNAME
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ include "slack-invite-mgr.smtpSecretsName" . }}
+                      key: SMTP2GO_USERNAME
+                - name: SMTP2GO_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ include "slack-invite-mgr.smtpSecretsName" . }}
+                      key: SMTP2GO_PASSWORD
+                - name: DASHBOARD_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ include "slack-invite-mgr.smtpSecretsName" . }}
+                      key: DASHBOARD_URL
+                {{- else }}
+                - name: GOOGLE_SHEET_NAME
+                  valueFrom:
+                    configMapKeyRef:
+                      name: {{ include "slack-invite-mgr.fullname" . }}-config
+                      key: GOOGLE_SHEET_NAME
+                {{- end }}
+                {{- with .Values.sheets.extraEnv }}
+                {{- toYaml . | nindent 16 }}
+                {{- end }}
+              volumeMounts:
+                - name: google-credentials
+                  mountPath: /app/credentials
+                  readOnly: true
+              resources:
+                {{- toYaml .Values.sheets.resources | nindent 16 }}
+          volumes:
+            - name: google-credentials
+              secret:
+                secretName: {{ include "slack-invite-mgr.googleCredentialsSecretName" . }}
+          {{- with .Values.sheets.nodeSelector }}
+          nodeSelector:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.sheets.tolerations }}
+          tolerations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+{{- end }}

--- a/helm/slack-invite-mgr/templates/web-deployment.yaml
+++ b/helm/slack-invite-mgr/templates/web-deployment.yaml
@@ -1,0 +1,78 @@
+{{- if .Values.web.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "slack-invite-mgr.fullname" . }}-web
+  labels:
+    {{- include "slack-invite-mgr.web.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.web.replicas }}
+  selector:
+    matchLabels:
+      {{- include "slack-invite-mgr.web.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.web.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "slack-invite-mgr.web.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- include "slack-invite-mgr.imagePullSecrets" . | nindent 6 }}
+      serviceAccountName: {{ include "slack-invite-mgr.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: web
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: {{ include "slack-invite-mgr.web.image" . }}
+          imagePullPolicy: {{ .Values.web.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.web.port }}
+              protocol: TCP
+          env:
+            {{- if .Values.web.env.apiUrl }}
+            - name: API_URL
+              value: {{ .Values.web.env.apiUrl | quote }}
+            {{- else }}
+            # Default to internal backend service URL
+            - name: API_URL
+              value: "http://{{ include "slack-invite-mgr.fullname" . }}-backend:{{ .Values.backend.port }}"
+            {{- end }}
+            {{- if .Values.web.env.publicUrl }}
+            - name: PUBLIC_URL
+              value: {{ .Values.web.env.publicUrl | quote }}
+            {{- end }}
+            {{- with .Values.web.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.web.healthCheck.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.web.healthCheck.initialDelaySeconds }}
+            periodSeconds: {{ .Values.web.healthCheck.periodSeconds }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.web.healthCheck.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.web.healthCheck.initialDelaySeconds }}
+            periodSeconds: {{ .Values.web.healthCheck.periodSeconds }}
+          resources:
+            {{- toYaml .Values.web.resources | nindent 12 }}
+      {{- with .Values.web.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.web.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.web.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/helm/slack-invite-mgr/templates/web-service.yaml
+++ b/helm/slack-invite-mgr/templates/web-service.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.web.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "slack-invite-mgr.fullname" . }}-web
+  labels:
+    {{- include "slack-invite-mgr.web.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.web.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "slack-invite-mgr.web.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/helm/slack-invite-mgr/values-prod.yaml
+++ b/helm/slack-invite-mgr/values-prod.yaml
@@ -1,0 +1,51 @@
+# Production values for slack-invite-mgr
+# Override these values for your production deployment
+
+global:
+  githubUsername: "your-github-username"
+
+backend:
+  replicas: 2
+  resources:
+    requests:
+      cpu: 200m
+      memory: 256Mi
+    limits:
+      cpu: 1000m
+      memory: 512Mi
+
+web:
+  replicas: 2
+  env:
+    # Set this to the externally accessible API URL
+    apiUrl: "https://slack-invite.example.com/api"
+    publicUrl: "/slack-invite"
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 256Mi
+
+sheets:
+  # Run every 30 minutes in production
+  schedule: "*/30 * * * *"
+
+ingress:
+  host: slack-invite.example.com
+  path: /slack-invite
+  tls:
+    enabled: true
+    secretName: slack-invite-tls
+
+externalSecrets:
+  enabled: true
+  secretStoreName: "your-secret-store"
+  secretStoreKind: ClusterSecretStore
+  googleCredentials:
+    remoteRef: "prod/slack-invite/google-credentials"
+  appSecrets:
+    remoteRef: "prod/slack-invite/app"
+  smtpSecrets:
+    remoteRef: "prod/slack-invite/smtp"

--- a/helm/slack-invite-mgr/values.yaml
+++ b/helm/slack-invite-mgr/values.yaml
@@ -1,0 +1,191 @@
+# Default values for slack-invite-mgr
+
+global:
+  # Image registry (default: GitHub Container Registry)
+  imageRegistry: ghcr.io
+  # GitHub username for image repository
+  githubUsername: ""
+  # Image pull secrets (optional)
+  imagePullSecrets: []
+
+# Backend API configuration
+backend:
+  enabled: true
+  image:
+    repository: slack-invite-mgr-backend
+    tag: latest
+    pullPolicy: IfNotPresent
+  replicas: 1
+  port: 8080
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 256Mi
+  # Health check endpoints
+  healthCheck:
+    path: /health
+    initialDelaySeconds: 5
+    periodSeconds: 10
+  # Additional environment variables
+  extraEnv: []
+  # Pod annotations
+  podAnnotations: {}
+  # Node selector
+  nodeSelector: {}
+  # Tolerations
+  tolerations: []
+  # Affinity rules
+  affinity: {}
+
+# Frontend web configuration
+web:
+  enabled: true
+  image:
+    repository: slack-invite-mgr-web
+    tag: latest
+    pullPolicy: IfNotPresent
+  replicas: 1
+  port: 80
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+    limits:
+      cpu: 200m
+      memory: 128Mi
+  env:
+    # API URL that the browser will use (must be externally accessible)
+    apiUrl: ""
+    # Public URL path for subpath deployment (e.g., /slack-invite)
+    publicUrl: ""
+  # Health check
+  healthCheck:
+    path: /
+    initialDelaySeconds: 5
+    periodSeconds: 10
+  # Additional environment variables
+  extraEnv: []
+  # Pod annotations
+  podAnnotations: {}
+  # Node selector
+  nodeSelector: {}
+  # Tolerations
+  tolerations: []
+  # Affinity rules
+  affinity: {}
+
+# Sheets sync CronJob configuration
+sheets:
+  enabled: true
+  image:
+    repository: slack-invite-mgr-sheets
+    tag: latest
+    pullPolicy: IfNotPresent
+  # Cron schedule (default: every hour)
+  schedule: "0 * * * *"
+  # Concurrency policy: Forbid, Replace, or Allow
+  concurrencyPolicy: Forbid
+  # Number of successful job history to keep
+  successfulJobsHistoryLimit: 3
+  # Number of failed job history to keep
+  failedJobsHistoryLimit: 3
+  # Restart policy for the job
+  restartPolicy: OnFailure
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 256Mi
+  # Additional environment variables
+  extraEnv: []
+  # Pod annotations
+  podAnnotations: {}
+  # Node selector
+  nodeSelector: {}
+  # Tolerations
+  tolerations: []
+
+# Traefik Ingress configuration
+ingress:
+  enabled: true
+  # Hostname for the ingress
+  host: slack-invite.example.com
+  # Path prefix (should match web.env.publicUrl)
+  path: /slack-invite
+  # Traefik entrypoints
+  entryPoints:
+    - websecure
+  # TLS configuration
+  tls:
+    enabled: true
+    # Secret name for TLS certificate (cert-manager or manual)
+    secretName: slack-invite-tls
+  # Additional Traefik middlewares to apply
+  middlewares: []
+  # Annotations for the IngressRoute
+  annotations: {}
+
+# External Secrets Operator configuration
+externalSecrets:
+  enabled: true
+  # Name of the SecretStore or ClusterSecretStore to use
+  secretStoreName: ""
+  # Kind: SecretStore or ClusterSecretStore
+  secretStoreKind: ClusterSecretStore
+  # Refresh interval for secrets
+  refreshInterval: 1h
+  # Google credentials secret configuration
+  googleCredentials:
+    # Key/path in the external secret store
+    remoteRef: google-credentials
+    # Property name in the secret (for key-value stores)
+    property: credentials.json
+  # Application secrets (spreadsheet ID, sheet name)
+  appSecrets:
+    remoteRef: slack-invite/app
+    # Map of secret keys to environment variable names
+    keys:
+      spreadsheetId: GOOGLE_SPREADSHEET_ID
+      sheetName: GOOGLE_SHEET_NAME
+  # SMTP secrets for email notifications
+  smtpSecrets:
+    remoteRef: slack-invite/smtp
+    keys:
+      emailRecipient: EMAIL_RECIPIENT
+      fromEmail: SMTP2GO_FROM_EMAIL
+      username: SMTP2GO_USERNAME
+      password: SMTP2GO_PASSWORD
+      dashboardUrl: DASHBOARD_URL
+
+# ConfigMap for non-sensitive configuration
+config:
+  # Google Sheet name (if not using external secrets for this)
+  googleSheetName: "Sheet1"
+
+# Service account configuration
+serviceAccount:
+  # Create a service account
+  create: true
+  # Annotations for the service account
+  annotations: {}
+  # Name override (defaults to release name)
+  name: ""
+
+# Pod security context
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  fsGroup: 1000
+
+# Container security context
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: false
+  capabilities:
+    drop:
+      - ALL


### PR DESCRIPTION
## Summary

- Add Helm chart (`helm/slack-invite-mgr/`) for deploying the application to Kubernetes
- Backend API deployment with health checks and Google credentials mounting
- Frontend web deployment with configurable `API_URL` and `PUBLIC_URL`
- Sheets sync as CronJob with configurable schedule
- Traefik IngressRoute with TLS support and path-based routing
- External Secrets Operator (ESO) integration for secret management
- ArgoCD Application manifest for GitOps deployment

## Components

| Component | Type | Description |
|-----------|------|-------------|
| Backend API | Deployment + Service | Go REST API server (port 8080) |
| Frontend Web | Deployment + Service | React SPA served by nginx (port 80) |
| Sheets Sync | CronJob | Scheduled Google Sheets synchronization |
| Ingress | Traefik IngressRoute | TLS-enabled ingress with path routing |
| External Secrets | ExternalSecret | Secrets fetched from external store |

## Prerequisites

- Kubernetes 1.19+
- Traefik Ingress Controller
- External Secrets Operator installed with configured SecretStore
- ArgoCD for GitOps deployment

## Test plan

- [ ] Review Helm templates for correctness
- [ ] Run `helm template` to validate rendered manifests
- [ ] Deploy to test cluster and verify all components start
- [ ] Verify ingress routing works correctly
- [ ] Verify CronJob executes on schedule

🤖 Generated with [Claude Code](https://claude.com/claude-code)